### PR TITLE
Missing page parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ list = Myra::Domains.list
 domain[0].name
 # => 'my-awesome-name.com'
 ```
+
+`list` takes one parameter which determines the `page` to be shown.
+
 #### Create
 
 ```ruby
@@ -98,6 +101,9 @@ domain = Myra::Domain.new id: 1
 records = Myra::DnsRecords.list(domain)
 # => [Myra::DnsRecord, Myra::DnsRecord, ...]
 ```
+
+
+`list` takes one additional parameter which determines the `page` to be shown.
 
 #### Create
 

--- a/lib/myra/actions/dns_records.rb
+++ b/lib/myra/actions/dns_records.rb
@@ -5,8 +5,8 @@ module Myra
     extend DomainHandler
     PATH = '/dnsRecords/{domain}'
 
-    def self.list(domain)
-      values = handle Request.new(path: path(domain))
+    def self.list(domain, page = 1)
+      values = handle Request.new(path: "#{path(domain)}/#{page}")
       values['list'].map { |record| DnsRecord.from_hash(record) }
     end
 

--- a/lib/myra/actions/domains.rb
+++ b/lib/myra/actions/domains.rb
@@ -6,8 +6,8 @@ module Myra
     extend RequestHandler
     PATH = '/domains'
 
-    def self.list
-      values = handle Request.new(path: PATH)
+    def self.list(page = 1)
+      values = handle Request.new(path: "#{PATH}/#{page}")
       values['list'].map { |domain| Domain.from_hash(domain) }
     end
 

--- a/lib/myra/version.rb
+++ b/lib/myra/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Myra
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/actions/dns_records_spec.rb
+++ b/spec/actions/dns_records_spec.rb
@@ -23,7 +23,9 @@ describe Myra::DnsRecords do
   end
   let(:request_body) { '' }
   describe '.list' do
+    let(:url) { 'https://api.myracloud.com/en/rapi/dnsRecords/foo.com/1' }
     let(:method) { :get }
+
     let(:response) do
       {
         status: 200,

--- a/spec/actions/domains_spec.rb
+++ b/spec/actions/domains_spec.rb
@@ -22,6 +22,7 @@ describe Myra::Domains do
   end
 
   describe '.list' do
+    let(:url) { 'https://api.myracloud.com/en/rapi/domains/1' }
     let!(:stub) do
       stub_request(:get, url).to_return(response)
     end
@@ -49,6 +50,23 @@ describe Myra::Domains do
         expect do
           described_class.list
         end.to raise_error(Myra::APIAuthError)
+      end
+    end
+
+    describe 'page parameter' do
+      let(:response) do
+        {
+          status: 200,
+          body: load_json('successful_domains_response')
+        }
+      end
+      let(:url) { 'https://api.myracloud.com/en/rapi/domains/42' }
+      let!(:stub) do
+        stub_request(:get, url).to_return(response)
+      end
+      it 'can use the page parameter' do
+        domains = described_class.list(42)
+        expect(stub).to have_been_made.once
       end
     end
   end


### PR DESCRIPTION
As addressed in #1. 

MyraCloud now unifies the use of the `page` parameter, it should be required across all calls. It is still a bit inconsistent, but will be implemented as a required parameter in the future.
